### PR TITLE
Issue 7: convert pre-build to post-extract

### DIFF
--- a/post-extract
+++ b/post-extract
@@ -3,8 +3,8 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/config"
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
-solr-pre-build() {
-  declare APP="$1"
+solr-post-extract() {
+  declare APP="$1" TMPDIR="$2"
   local LINKED_SERVICES SERVICE SERVICE_CONTAINER_ID SERVICE_ROOT TMPDIR
 
   LINKED_SERVICES="$(solr-linked-services "$APP")"
@@ -13,28 +13,23 @@ solr-pre-build() {
     return
   fi
 
-  TMPDIR=$(mktemp -d)
-  trap 'rm -rf "$TMP_WORK_DIR" > /dev/null' RETURN
-
-  cd "${TMPDIR}" && git clone -q "${DOKKU_ROOT}/${APP}" repo > /dev/null 2>&1
-
-  if [[ -f "${TMPDIR}/repo/solr/schema.xml" ]]; then
+  if [[ -f "${TMPDIR}/solr/schema.xml" ]]; then
     for SERVICE in $LINKED_SERVICES; do
       dokku_log_info1_quiet "Copying solr/schema.xml to service conf/schema.xml"
       SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
       SERVICE_CONTAINER_ID="$(cat "$SERVICE_ROOT/ID")"
-      docker cp "${TMPDIR}/repo/solr/schema.xml" "${SERVICE_CONTAINER_ID}:/opt/solr/server/solr/mycores/${SERVICE}/conf/schema.xml"
+      docker cp "${TMPDIR}/solr/schema.xml" "${SERVICE_CONTAINER_ID}:/opt/solr/server/solr/mycores/${SERVICE}/conf/schema.xml"
       sudo /bin/chown 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/schema.xml"
       sudo /bin/chgrp 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/schema.xml"
     done
   fi
- 
-  if [[ -f "${TMPDIR}/repo/solr/solrconfig.xml" ]]; then
+
+  if [[ -f "${TMPDIR}/solr/solrconfig.xml" ]]; then
     for SERVICE in $LINKED_SERVICES; do
       dokku_log_info1_quiet "Copying solr/solrconfig.xml to service' conf/solrconfig.xml"
       SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
       SERVICE_CONTAINER_ID="$(cat "$SERVICE_ROOT/ID")"
-      docker cp "${TMPDIR}/repo/solr/solrconfig.xml" "${SERVICE_CONTAINER_ID}:/opt/solr/server/solr/mycores/${SERVICE}/conf/solrconfig.xml"
+      docker cp "${TMPDIR}/solr/solrconfig.xml" "${SERVICE_CONTAINER_ID}:/opt/solr/server/solr/mycores/${SERVICE}/conf/solrconfig.xml"
       sudo /bin/chown 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/solrconfig.xml"
       sudo /bin/chgrp 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/solrconfig.xml"
     done
@@ -56,4 +51,4 @@ solr-linked-services() {
   done
 }
 
-solr-pre-build "$1"
+solr-post-extract "$@"

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -1,1 +1,0 @@
-pre-build

--- a/pre-build-dockerfile
+++ b/pre-build-dockerfile
@@ -1,1 +1,0 @@
-pre-build


### PR DESCRIPTION
Renames pre-build to post-extract. Updates the code to receive tmpdir from $2, and not clone the git repo to pull the solr config.