### PR TITLE
Allow more config files for solr (#9).

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ OR
 - Change SOLR_DATABASE_SCHEME to the desired setting
 - Relink the service
 
+## Core settings
+
+You can configure the solr core adding files to `/solr` directory in your application. Fore example, files like `protwords.txt`, `solrconfig.xml` and other schema extra files.
+
 ## Disabling `docker pull` calls
 
 If you wish to disable the `docker pull` calls that the plugin triggers, you may set the `SOLR_DISABLE_PULL` environment variable to `true`. Once disabled, you will need to pull the service image you wish to deploy as shown in the `stderr` output.

--- a/post-extract
+++ b/post-extract
@@ -14,25 +14,14 @@ solr-post-extract() {
     return
   fi
 
-  if [[ -f "${TMPDIR}/solr/schema.xml" ]]; then
+  if [[ -d "${TMPDIR}/solr" ]]; then
     for SERVICE in $LINKED_SERVICES; do
-      dokku_log_info1_quiet "Copying solr/schema.xml to service conf/schema.xml"
+      dokku_log_info1_quiet "Copying solr to service conf"
       SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
       SERVICE_CONTAINER_ID="$(cat "$SERVICE_ROOT/ID")"
-      docker cp "${TMPDIR}/solr/schema.xml" "${SERVICE_CONTAINER_ID}:/opt/solr/server/solr/mycores/${SERVICE}/conf/schema.xml"
-      sudo /bin/chown 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/schema.xml"
-      sudo /bin/chgrp 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/schema.xml"
-    done
-  fi
-
-  if [[ -f "${TMPDIR}/solr/solrconfig.xml" ]]; then
-    for SERVICE in $LINKED_SERVICES; do
-      dokku_log_info1_quiet "Copying solr/solrconfig.xml to service' conf/solrconfig.xml"
-      SERVICE_ROOT="${PLUGIN_DATA_ROOT}/${SERVICE}"
-      SERVICE_CONTAINER_ID="$(cat "$SERVICE_ROOT/ID")"
-      docker cp "${TMPDIR}/solr/solrconfig.xml" "${SERVICE_CONTAINER_ID}:/opt/solr/server/solr/mycores/${SERVICE}/conf/solrconfig.xml"
-      sudo /bin/chown 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/solrconfig.xml"
-      sudo /bin/chgrp 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/solrconfig.xml"
+      for f in ${TMPDIR}/solr/*; do docker cp $f "${SERVICE_CONTAINER_ID}:/opt/solr/server/solr/mycores/${SERVICE}/conf/"; done
+      sudo /bin/chown 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/"*
+      sudo /bin/chgrp 8983 "${SERVICE_ROOT}/data/${SERVICE}/conf/"*
     done
   fi
 }


### PR DESCRIPTION
I needed more a whole new schema, so decided send a PR for #9 

Instead of copying two files only (solrconfig.xml and schema.xml), I changed the `post-extract` script to copy all the files found in `/solr`.

My use case was Drupal, which detects the solr server version and provides a zip file with the required configuration with a custom schema.