### PR TITLE
feat: add network alias that is $SERVICE_NAME.$SERVICE_TYPE 

### DIFF
--- a/functions
+++ b/functions
@@ -120,7 +120,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container create"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "$network_alias" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-create-network" | tr "," "\n")
   fi
   suppress_output "$DOCKER_BIN" container start "$(cat "$SERVICE_ROOT/ID")"
@@ -128,7 +128,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container start"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "$network_alias" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-start-network" | tr "," "\n")
   fi
 

--- a/functions
+++ b/functions
@@ -73,6 +73,8 @@ service_create_container() {
     export CONFIG_OPTIONS="$(cat "$SERVICE_ROOT/CONFIG_OPTIONS")"
   fi
 
+  local network_alias="$(service_dns_hostname "$SERVICE")"
+
   rm -f "$SERVICE_ROOT/ID"
   declare -a DOCKER_ARGS
   DOCKER_ARGS=()
@@ -89,7 +91,7 @@ service_create_container() {
   LINK_CONTAINER_DOCKER_ARGS=()
   LINK_CONTAINER_DOCKER_ARGS+=("--rm")
   LINK_CONTAINER_DOCKER_ARGS+=("--link")
-  LINK_CONTAINER_DOCKER_ARGS+=("$SERVICE_NAME:$PLUGIN_COMMAND_PREFIX")
+  LINK_CONTAINER_DOCKER_ARGS+=("$SERVICE_NAME:$network_alias")
 
   [[ -f "$SERVICE_ROOT/SERVICE_MEMORY" ]] && SERVICE_MEMORY="$(cat "$SERVICE_ROOT/SERVICE_MEMORY")"
   if [[ -n "$SERVICE_MEMORY" ]]; then
@@ -104,7 +106,6 @@ service_create_container() {
   [[ -f "$SERVICE_ROOT/IMAGE" ]] && PLUGIN_IMAGE="$(cat "$SERVICE_ROOT/IMAGE")"
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && PLUGIN_IMAGE_VERSION="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
 
-  local network_alias="dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")"
   local network="$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "initial-network")"
   if [[ -n "$network" ]]; then
     DOCKER_ARGS+=("--network=${network}")

--- a/functions
+++ b/functions
@@ -104,10 +104,9 @@ service_create_container() {
   [[ -f "$SERVICE_ROOT/IMAGE" ]] && PLUGIN_IMAGE="$(cat "$SERVICE_ROOT/IMAGE")"
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && PLUGIN_IMAGE_VERSION="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
 
-  local network_alias="$SERVICE_NAME"
+  local network_alias="dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")"
   local network="$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "initial-network")"
   if [[ -n "$network" ]]; then
-    network_alias="dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")"
     DOCKER_ARGS+=("--network=${network}")
     DOCKER_ARGS+=("--network-alias=${network_alias}")
     LINK_CONTAINER_DOCKER_ARGS+=("--network=${network}")
@@ -120,7 +119,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container create"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "$network_alias" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-create-network" | tr "," "\n")
   fi
   suppress_output "$DOCKER_BIN" container start "$(cat "$SERVICE_ROOT/ID")"
@@ -128,7 +127,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container start"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "$network_alias" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-start-network" | tr "," "\n")
   fi
 

--- a/functions
+++ b/functions
@@ -120,7 +120,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container create"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "$SERVICE_NAME" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "$network_alias" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-create-network" | tr "," "\n")
   fi
   suppress_output "$DOCKER_BIN" container start "$(cat "$SERVICE_ROOT/ID")"
@@ -128,7 +128,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container start"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "$SERVICE_NAME" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "$network_alias" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-start-network" | tr "," "\n")
   fi
 

--- a/functions
+++ b/functions
@@ -107,7 +107,7 @@ service_create_container() {
   local network_alias="$SERVICE_NAME"
   local network="$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "initial-network")"
   if [[ -n "$network" ]]; then
-    network_alias="$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX"
+    network_alias="dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")"
     DOCKER_ARGS+=("--network=${network}")
     DOCKER_ARGS+=("--network-alias=${network_alias}")
     LINK_CONTAINER_DOCKER_ARGS+=("--network=${network}")
@@ -120,7 +120,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container create"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-create-network" | tr "," "\n")
   fi
   suppress_output "$DOCKER_BIN" container start "$(cat "$SERVICE_ROOT/ID")"
@@ -128,7 +128,7 @@ service_create_container() {
     dokku_log_verbose_quiet "Connecting to networks after container start"
     while read -r line || [[ -n "$line" ]]; do
       dokku_log_verbose_quiet "- $line"
-      "$DOCKER_BIN" network connect --alias "$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX" "$line" "$SERVICE_NAME"
+      "$DOCKER_BIN" network connect --alias "dokku-$PLUGIN_COMMAND_PREFIX-$(get_database_name "$SERVICE")" "$line" "$SERVICE_NAME"
     done < <(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "post-start-network" | tr "," "\n")
   fi
 

--- a/functions
+++ b/functions
@@ -104,9 +104,10 @@ service_create_container() {
   [[ -f "$SERVICE_ROOT/IMAGE" ]] && PLUGIN_IMAGE="$(cat "$SERVICE_ROOT/IMAGE")"
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && PLUGIN_IMAGE_VERSION="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
 
-  local network_alias="$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX"
+  local network_alias="$SERVICE_NAME"
   local network="$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "initial-network")"
   if [[ -n "$network" ]]; then
+    network_alias="$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX"
     DOCKER_ARGS+=("--network=${network}")
     DOCKER_ARGS+=("--network-alias=${network_alias}")
     LINK_CONTAINER_DOCKER_ARGS+=("--network=${network}")

--- a/functions
+++ b/functions
@@ -104,10 +104,11 @@ service_create_container() {
   [[ -f "$SERVICE_ROOT/IMAGE" ]] && PLUGIN_IMAGE="$(cat "$SERVICE_ROOT/IMAGE")"
   [[ -f "$SERVICE_ROOT/IMAGE_VERSION" ]] && PLUGIN_IMAGE_VERSION="$(cat "$SERVICE_ROOT/IMAGE_VERSION")"
 
+  local network_alias="$(get_database_name "$SERVICE").$PLUGIN_COMMAND_PREFIX"
   local network="$(fn-plugin-property-get "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "initial-network")"
   if [[ -n "$network" ]]; then
     DOCKER_ARGS+=("--network=${network}")
-    DOCKER_ARGS+=("--network-alias=$SERVICE_NAME")
+    DOCKER_ARGS+=("--network-alias=${network_alias}")
     LINK_CONTAINER_DOCKER_ARGS+=("--network=${network}")
   fi
 
@@ -131,7 +132,7 @@ service_create_container() {
   fi
 
   dokku_log_verbose_quiet "Waiting for container to be ready"
-  if ! suppress_output "$DOCKER_BIN" container run "${LINK_CONTAINER_DOCKER_ARGS[@]}" "$PLUGIN_WAIT_IMAGE" -c "$SERVICE_NAME:$PLUGIN_DATASTORE_WAIT_PORT"; then
+  if ! suppress_output "$DOCKER_BIN" container run "${LINK_CONTAINER_DOCKER_ARGS[@]}" "$PLUGIN_WAIT_IMAGE" -c "$network_alias:$PLUGIN_DATASTORE_WAIT_PORT"; then
     dokku_log_info2_quiet "Start of $SERVICE container output"
     dokku_container_log_verbose_quiet "$SERVICE_NAME"
     dokku_log_info2_quiet "End of $SERVICE container output"

--- a/functions
+++ b/functions
@@ -78,7 +78,7 @@ service_create_container() {
   DOCKER_ARGS=()
   DOCKER_ARGS+=("--cidfile=$SERVICE_ROOT/ID")
   DOCKER_ARGS+=("--env-file=$SERVICE_ROOT/ENV")
-  DOCKER_ARGS+=("--hostname=$SERVICE")
+  DOCKER_ARGS+=("--hostname=$SERVICE_NAME")
   DOCKER_ARGS+=("--label=dokku.service=$PLUGIN_COMMAND_PREFIX")
   DOCKER_ARGS+=("--label=dokku=service")
   DOCKER_ARGS+=("--name=$SERVICE_NAME")

--- a/tests/link_networks.bats
+++ b/tests/link_networks.bats
@@ -253,7 +253,7 @@ teardown() {
   assert_output_contains bridge
   assert_output_contains custom-network
 
-  run docker inspect dokku.$PLUGIN_COMMAND_PREFIX.ls -f '{{range $net,$v := .NetworkSettings.Networks}}{{range $k,$alias := $v.Aliases}}{{printf "alias:%s\n" $alias}}{{end}}{{end}}'
+  run docker inspect dokku.$PLUGIN_COMMAND_PREFIX.lsa -f '{{range $net,$v := .NetworkSettings.Networks}}{{range $k,$alias := $v.Aliases}}{{printf "alias:%s\n" $alias}}{{end}}{{end}}'
   echo "output: $output"
   echo "status: $status"
   assert_success

--- a/tests/link_networks.bats
+++ b/tests/link_networks.bats
@@ -53,7 +53,7 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
-  assert_output_contains "alias:ls.$PLUGIN_COMMAND_PREFIX"
+  assert_output_contains "alias:dokku-$PLUGIN_COMMAND_PREFIX-ls"
   assert_output_contains "alias:ls"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls initial-network
@@ -120,6 +120,14 @@ teardown() {
   assert_success
   assert_output_contains custom-network
   assert_output_contains bridge
+
+  run docker inspect dokku.$PLUGIN_COMMAND_PREFIX.ls -f '{{range $net,$v := .NetworkSettings.Networks}}{{range $k,$alias := $v.Aliases}}{{printf "alias:%s\n" $alias}}{{end}}{{end}}'
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
+  assert_output_contains "alias:dokku-$PLUGIN_COMMAND_PREFIX-ls"
+  assert_output_contains "alias:ls"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls post-create-network
   echo "output: $output"
@@ -191,7 +199,7 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
-  assert_output_contains "alias:ls.$PLUGIN_COMMAND_PREFIX"
+  assert_output_contains "alias:dokku-$PLUGIN_COMMAND_PREFIX-ls"
   assert_output_contains "alias:ls"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls post-start-network
@@ -258,7 +266,7 @@ teardown() {
   echo "status: $status"
   assert_success
   assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.lsa"
-  assert_output_contains "alias:lsa.$PLUGIN_COMMAND_PREFIX"
+  assert_output_contains "alias:dokku-$PLUGIN_COMMAND_PREFIX-lsa"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:destroy" lsa --force
   echo "output: $output"

--- a/tests/link_networks.bats
+++ b/tests/link_networks.bats
@@ -257,9 +257,8 @@ teardown() {
   echo "output: $output"
   echo "status: $status"
   assert_success
-  assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
-  assert_output_contains "alias:ls.$PLUGIN_COMMAND_PREFIX"
-  assert_output_contains "alias:ls"
+  assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.lsa"
+  assert_output_contains "alias:lsa.$PLUGIN_COMMAND_PREFIX"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:destroy" lsa --force
   echo "output: $output"

--- a/tests/link_networks.bats
+++ b/tests/link_networks.bats
@@ -54,7 +54,6 @@ teardown() {
   assert_success
   assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
   assert_output_contains "alias:dokku-$PLUGIN_COMMAND_PREFIX-ls"
-  assert_output_contains "alias:ls"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls initial-network
   echo "output: $output"
@@ -127,7 +126,6 @@ teardown() {
   assert_success
   assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
   assert_output_contains "alias:dokku-$PLUGIN_COMMAND_PREFIX-ls"
-  assert_output_contains "alias:ls"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls post-create-network
   echo "output: $output"
@@ -200,7 +198,6 @@ teardown() {
   assert_success
   assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
   assert_output_contains "alias:dokku-$PLUGIN_COMMAND_PREFIX-ls"
-  assert_output_contains "alias:ls"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls post-start-network
   echo "output: $output"

--- a/tests/link_networks.bats
+++ b/tests/link_networks.bats
@@ -48,6 +48,14 @@ teardown() {
   assert_output_contains bridge 0
   assert_output_contains custom-network
 
+  run docker inspect dokku.$PLUGIN_COMMAND_PREFIX.ls -f '{{range $net,$v := .NetworkSettings.Networks}}{{range $k,$alias := $v.Aliases}}{{printf "alias:%s\n" $alias}}{{end}}{{end}}'
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
+  assert_output_contains "alias:ls.$PLUGIN_COMMAND_PREFIX"
+  assert_output_contains "alias:ls"
+
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls initial-network
   echo "output: $output"
   echo "status: $status"
@@ -178,6 +186,14 @@ teardown() {
   assert_output_contains bridge
   assert_output_contains custom-network
 
+  run docker inspect dokku.$PLUGIN_COMMAND_PREFIX.ls -f '{{range $net,$v := .NetworkSettings.Networks}}{{range $k,$alias := $v.Aliases}}{{printf "alias:%s\n" $alias}}{{end}}{{end}}'
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
+  assert_output_contains "alias:ls.$PLUGIN_COMMAND_PREFIX"
+  assert_output_contains "alias:ls"
+
   run dokku "$PLUGIN_COMMAND_PREFIX:set" ls post-start-network
   echo "output: $output"
   echo "status: $status"
@@ -236,6 +252,14 @@ teardown() {
   assert_success
   assert_output_contains bridge
   assert_output_contains custom-network
+
+  run docker inspect dokku.$PLUGIN_COMMAND_PREFIX.ls -f '{{range $net,$v := .NetworkSettings.Networks}}{{range $k,$alias := $v.Aliases}}{{printf "alias:%s\n" $alias}}{{end}}{{end}}'
+  echo "output: $output"
+  echo "status: $status"
+  assert_success
+  assert_output_contains "alias:dokku.$PLUGIN_COMMAND_PREFIX.ls"
+  assert_output_contains "alias:ls.$PLUGIN_COMMAND_PREFIX"
+  assert_output_contains "alias:ls"
 
   run dokku "$PLUGIN_COMMAND_PREFIX:destroy" lsa --force
   echo "output: $output"


### PR DESCRIPTION
This alias is in addition to the existing `dokku.$SERVICE_TYPE.$SERVICE_NAME` network alias that is derived from the hostname.

Also use the service name (`dokku.$SERVICE_TYPE.$SERVICE_NAME`) as the hostname for all containers.